### PR TITLE
Updated a deprecated method and fixed linter warnings

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -33,7 +33,7 @@ Future<void> initApp() async {
     debugPrint(e.toString());
   }
 
-  await runZoned<Future<void>>(
+  await runZonedGuarded<Future<void>>(
     () async {
       runApp(
         EasyLocalization(
@@ -46,7 +46,7 @@ Future<void> initApp() async {
         ),
       );
     },
-    onError: (error, StackTrace stackTrace) async {
+    (error, StackTrace stackTrace) async {
       if (Config.appMode == AppMode.release) {
         await Crashlytics.instance.recordError(error, stackTrace);
         await getErrorLogger().logEvent(
@@ -90,7 +90,7 @@ class _AppState extends State<App> {
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 Text(
-                  'welcome_message'.tr() as String,
+                  'welcome_message'.tr(),
                 ),
                 Text(
                   RemoteConfigRepository().getString('welcome_msg'),

--- a/lib/src/app_update/app_update.dart
+++ b/lib/src/app_update/app_update.dart
@@ -42,9 +42,9 @@ Future<void> promptAppUpdate(BuildContext context) async {
   if (update == UpdateMode.flexibleUpdate) {
     Scaffold.of(context).showSnackBar(
       SnackBar(
-        content: Text('flexible_update_msg'.tr() as String),
+        content: Text('flexible_update_msg'.tr()),
         action: SnackBarAction(
-          label: 'btn_update'.tr() as String,
+          label: 'btn_update'.tr(),
           onPressed: () => openStore(),
         ),
       ),
@@ -57,12 +57,12 @@ Future<void> promptAppUpdate(BuildContext context) async {
       barrierDismissible: false,
       builder: (context) {
         return AlertDialog(
-          title: Text('title_immediate_update'.tr() as String),
-          content: Text('content_immediate_update'.tr() as String),
+          title: Text('title_immediate_update'.tr()),
+          content: Text('content_immediate_update'.tr()),
           actions: <Widget>[
             FlatButton(
               onPressed: () => openStore(),
-              child: Text('btn_update'.tr() as String),
+              child: Text('btn_update'.tr()),
             )
           ],
         );


### PR DESCRIPTION
Updated runZoned to runZonedGuarded and removed redundant 'as String' conversions